### PR TITLE
Remove unneeded dependency on bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TARGET=bim
-CFLAGS=-g -O2 -std=c99 -Wvla -pedantic -Wall -Wextra -I. $(shell bash docs/git-tag) -Wno-unused-parameter -Wno-unused-result
+CFLAGS=-g -O2 -std=c99 -Wvla -pedantic -Wall -Wextra -I. $(shell sh docs/git-tag) -Wno-unused-parameter -Wno-unused-result
 LDFLAGS=-rdynamic
 
 ifeq (Darwin,$(shell uname -s))

--- a/docs/git-tag
+++ b/docs/git-tag
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 command -v git >/dev/null 2>/dev/null || exit 0
 


### PR DESCRIPTION
Bash is referenced and invoked even though no bash specific features are used. This makes it harder to compile and package bim on systems which don't use bash.

This commit replaces bash with sh in Makefile and git-tag.
Since, in almost all cases, systems with bash have it linked to /bin/sh, they are not affected.